### PR TITLE
Fix delay plan for lunch&drink

### DIFF
--- a/lottery.go
+++ b/lottery.go
@@ -90,11 +90,9 @@ func (r LotteryResult) Show(w io.Writer) {
 
 func (r LotteryResult) PlanDelay(p Plan) time.Duration {
 	switch p {
-	case PlanLunch:
-		return 1 * time.Second
 	case PlanGold:
 		return 1 * time.Second
-	case PlanSilver:
+	case PlanSilver, PlanLunch, PlanDrink:
 		return 300 * time.Millisecond
 	}
 	return 0


### PR DESCRIPTION
2026/06/01の定例で対応した件です
ランチとドリンクの抽選時の出力時間を300msになるよう調整しました